### PR TITLE
Calculates and adds overtime data to schedule

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "basketball-reference-webscrapper"
-version = "0.6.2"
+version = "0.6.3"
 description = "Python package for Basketball Reference that gathers data by scraping the website"
 authors = ["Yannick Flores <yannick.flores1992@gmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
Adds overtime calculation to schedule data by analyzing total minutes played.

This enhancement introduces a function to determine overtime periods based on the 'MIN' column in the schedule data. It then populates the 'overtime' column with values like '', 'OT', '2OT', etc., based on the calculated overtime periods. The version is also bumped to 0.6.3.