### PR TITLE
Adds game_id to gamelog and schedule data

### DIFF
--- a/basketball_reference_webscrapper/params.yaml
+++ b/basketball_reference_webscrapper/params.yaml
@@ -201,6 +201,7 @@ gamelog_nba_api:
     - pf_opp
   list_columns_to_select:
     - id_season
+    - game_id
     - game_nb
     - game_date
     - extdom
@@ -243,6 +244,7 @@ schedule_nba_api:
     - streak_w_l
   list_columns_to_select:
     - id_season
+    - game_id
     - tm
     - game_date
     - time_start

--- a/basketball_reference_webscrapper/web_scrap_nba_api.py
+++ b/basketball_reference_webscrapper/web_scrap_nba_api.py
@@ -389,6 +389,7 @@ class WebScrapNBAApi:
         # NBA API columns to Basketball Reference mapping
         column_mapping = {
             'GAME_DATE': 'game_date',
+            'GAME_ID': 'game_id',
             'MATCHUP': 'matchup_raw',
             'WL': 'results',
             'PTS': 'pts_tm',
@@ -452,6 +453,7 @@ class WebScrapNBAApi:
         """
         # NBA API columns to Basketball Reference mapping
         column_mapping = {
+            'GAME_ID': 'game_id',
             'GAME_DATE': 'game_date',
             'MATCHUP': 'matchup_raw',
             'WL': 'w_l',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "basketball-reference-webscrapper"
-version = "0.7.2"
+version = "0.7.3"
 description = "Python package for Basketball Reference that gathers data by scraping the website"
 authors = ["Yannick Flores <yannick.flores1992@gmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
Adds the `game_id` to the columns selected for both gamelog and schedule data from the NBA API.

This allows for easier cross-referencing and analysis of game-specific data.

Increments the version to 0.7.3.