### PR TITLE
Adds team season validity to prevent duplicate data

### DIFF
--- a/basketball_reference_webscrapper/constants/team_season_validity.yaml
+++ b/basketball_reference_webscrapper/constants/team_season_validity.yaml
@@ -1,0 +1,139 @@
+# Team Season Validity Configuration
+# Maps NBA team abbreviations to their valid season ranges.
+# Used to prevent duplicate data from historical team name changes.
+#
+# Format:
+#   TEAM_ABBREV:
+#     start_season: YYYY  # First valid season (inclusive)
+#     end_season: YYYY    # Last valid season (inclusive), null = current
+#
+# Season notation: 2024 means the 2023-24 NBA season
+
+team_season_validity:
+  # Charlotte franchise (team_id: 1610612766)
+  # Charlotte Hornets rebranded from Bobcats in 2014-15 season
+  CHO:
+    start_season: 2015
+    end_season: null
+  CHA:
+    start_season: 2005
+    end_season: 2014
+
+  # Brooklyn Nets (team_id: 1610612751)
+  # Moved from New Jersey to Brooklyn in 2012-13 season
+  BRK:
+    start_season: 2013
+    end_season: null
+  NJN:
+    start_season: 2000
+    end_season: 2012
+
+  # Oklahoma City Thunder (team_id: 1610612760)
+  # Relocated from Seattle in 2008-09 season
+  OKC:
+    start_season: 2009
+    end_season: null
+  SEA:
+    start_season: 2000
+    end_season: 2008
+
+  # Memphis Grizzlies (team_id: 1610612763)
+  # Relocated from Vancouver in 2001-02 season
+  MEM:
+    start_season: 2002
+    end_season: null
+  VAN:
+    start_season: 2000
+    end_season: 2001
+
+  # New Orleans Pelicans (team_id: 1610612740)
+  # Rebranded from Hornets in 2013-14 season
+  NOP:
+    start_season: 2014
+    end_season: null
+  NOH:
+    start_season: 2003
+    end_season: 2013
+  NOK:
+    start_season: 2006
+    end_season: 2007  # Temporary during Katrina relocation
+
+  # Washington Wizards (team_id: 1610612764)
+  # Rebranded from Bullets in 1997-98 (before MIN_SUPPORTED_SEASON)
+  WAS:
+    start_season: 2000
+    end_season: null
+
+  # Teams with no name changes since 2000 (always valid)
+  ATL:
+    start_season: 2000
+    end_season: null
+  BOS:
+    start_season: 2000
+    end_season: null
+  CHI:
+    start_season: 2000
+    end_season: null
+  CLE:
+    start_season: 2000
+    end_season: null
+  DAL:
+    start_season: 2000
+    end_season: null
+  DEN:
+    start_season: 2000
+    end_season: null
+  DET:
+    start_season: 2000
+    end_season: null
+  GSW:
+    start_season: 2000
+    end_season: null
+  HOU:
+    start_season: 2000
+    end_season: null
+  IND:
+    start_season: 2000
+    end_season: null
+  LAC:
+    start_season: 2000
+    end_season: null
+  LAL:
+    start_season: 2000
+    end_season: null
+  MIA:
+    start_season: 2000
+    end_season: null
+  MIL:
+    start_season: 2000
+    end_season: null
+  MIN:
+    start_season: 2000
+    end_season: null
+  NYK:
+    start_season: 2000
+    end_season: null
+  ORL:
+    start_season: 2000
+    end_season: null
+  PHI:
+    start_season: 2000
+    end_season: null
+  PHO:
+    start_season: 2000
+    end_season: null
+  POR:
+    start_season: 2000
+    end_season: null
+  SAC:
+    start_season: 2000
+    end_season: null
+  SAS:
+    start_season: 2000
+    end_season: null
+  TOR:
+    start_season: 2000
+    end_season: null
+  UTA:
+    start_season: 2000
+    end_season: null

--- a/basketball_reference_webscrapper/utils/team_utils.py
+++ b/basketball_reference_webscrapper/utils/team_utils.py
@@ -1,0 +1,209 @@
+"""
+Utility functions for NBA team validation and season-based filtering.
+
+This module provides shared functionality for validating team abbreviations
+against their historically valid seasons, handling cases like:
+- CHO vs CHA (Charlotte Hornets vs Bobcats)
+- BRK vs NJN (Brooklyn vs New Jersey Nets)
+- OKC vs SEA (Oklahoma City vs Seattle SuperSonics)
+
+Used by both WebScrapNBAApi and WebScrapNBAApiBoxscore classes.
+"""
+
+from typing import Dict, List, Optional
+import importlib_resources
+import yaml
+
+from basketball_reference_webscrapper.utils.logs import get_logger
+
+__all__ = [
+    'load_team_season_validity',
+    'is_team_valid_for_season',
+    'filter_valid_teams_for_season'
+]
+
+logger = get_logger("TEAM_UTILS", log_level="INFO")
+
+# Module-level cache to avoid repeated file reads
+_team_season_validity_cache: Optional[Dict[str, Dict]] = None
+
+# Default minimum supported season
+MIN_SUPPORTED_SEASON = 2000
+
+
+def load_team_season_validity() -> Dict[str, Dict]:
+    """
+    Load and cache team season validity configuration from YAML file.
+
+    The configuration maps team abbreviations to their valid season ranges,
+    handling historical team name changes and relocations.
+
+    Returns:
+        Dict[str, Dict]: Dictionary mapping team abbreviations to their
+            valid season ranges with 'start_season' and 'end_season' keys.
+            Returns empty dict if file cannot be loaded.
+
+    Example:
+        >>> config = load_team_season_validity()
+        >>> config['CHO']
+        {'start_season': 2015, 'end_season': None}
+    """
+    global _team_season_validity_cache
+
+    if _team_season_validity_cache is not None:
+        return _team_season_validity_cache
+
+    try:
+        ref = (
+            importlib_resources.files("basketball_reference_webscrapper")
+            / "constants/team_season_validity.yaml"
+        )
+        with importlib_resources.as_file(ref) as path:
+            with open(path, encoding="utf-8") as f:
+                config = yaml.safe_load(f)
+                _team_season_validity_cache = config.get("team_season_validity", {})
+                logger.debug(
+                    "Loaded team season validity config with %d teams",
+                    len(_team_season_validity_cache)
+                )
+                return _team_season_validity_cache
+    except FileNotFoundError:
+        logger.warning(
+            "team_season_validity.yaml not found. "
+            "All teams will be considered valid for all seasons."
+        )
+        _team_season_validity_cache = {}
+        return _team_season_validity_cache
+    except Exception as e:
+        logger.warning(
+            "Could not load team_season_validity.yaml: %s. "
+            "All teams will be considered valid for all seasons.",
+            str(e)
+        )
+        _team_season_validity_cache = {}
+        return _team_season_validity_cache
+
+
+def is_team_valid_for_season(
+    team_abbr: str,
+    season: int,
+    min_supported_season: int = MIN_SUPPORTED_SEASON
+) -> bool:
+    """
+    Check if a team abbreviation is valid for a given season.
+
+    This handles historical team name changes. For example:
+    - CHO (Charlotte Hornets) is valid from 2015 onwards
+    - CHA (Charlotte Bobcats) is valid from 2005-2014
+    - Both map to the same team_id, but only one is valid per season
+
+    Args:
+        team_abbr (str): Team abbreviation (e.g., 'CHO', 'CHA', 'BOS').
+        season (int): Season year (e.g., 2024 for the 2023-24 season).
+        min_supported_season (int): Minimum supported season year.
+            Defaults to 2000.
+
+    Returns:
+        bool: True if team is valid for the season, False otherwise.
+            Returns True if team is not in config (backward compatibility).
+
+    Example:
+        >>> is_team_valid_for_season('CHO', 2024)
+        True
+        >>> is_team_valid_for_season('CHA', 2024)
+        False
+        >>> is_team_valid_for_season('CHA', 2010)
+        True
+    """
+    validity_config = load_team_season_validity()
+
+    # If no validity config loaded, assume all teams are valid
+    if not validity_config:
+        return True
+
+    # If team not in config, assume it's valid (backward compatibility)
+    if team_abbr not in validity_config:
+        return True
+
+    validity = validity_config[team_abbr]
+    start_season = validity.get("start_season", min_supported_season)
+    end_season = validity.get("end_season")  # None means current/ongoing
+
+    # Check if season falls within valid range
+    if season < start_season:
+        return False
+
+    if end_season is not None and season > end_season:
+        return False
+
+    return True
+
+
+def filter_valid_teams_for_season(
+    team_list: List[str],
+    season: int,
+    min_supported_season: int = MIN_SUPPORTED_SEASON
+) -> List[str]:
+    """
+    Filter a list of team abbreviations to only those valid for a season.
+
+    This is a convenience function that applies is_team_valid_for_season
+    to a list of teams.
+
+    Args:
+        team_list (List[str]): List of team abbreviations to filter.
+        season (int): Season year (e.g., 2024 for the 2023-24 season).
+        min_supported_season (int): Minimum supported season year.
+            Defaults to 2000.
+
+    Returns:
+        List[str]: Filtered list containing only team abbreviations
+            that are valid for the specified season.
+
+    Example:
+        >>> filter_valid_teams_for_season(['CHO', 'CHA', 'BOS'], 2024)
+        ['CHO', 'BOS']
+        >>> filter_valid_teams_for_season(['CHO', 'CHA', 'BOS'], 2010)
+        ['CHA', 'BOS']
+    """
+    return [
+        team for team in team_list
+        if is_team_valid_for_season(team, season, min_supported_season)
+    ]
+
+
+def get_excluded_teams_for_season(
+    team_list: List[str],
+    season: int
+) -> List[str]:
+    """
+    Get list of teams that are NOT valid for a given season.
+
+    Useful for logging which teams were filtered out.
+
+    Args:
+        team_list (List[str]): List of team abbreviations to check.
+        season (int): Season year.
+
+    Returns:
+        List[str]: List of team abbreviations that are invalid for the season.
+
+    Example:
+        >>> get_excluded_teams_for_season(['CHO', 'CHA', 'BOS'], 2024)
+        ['CHA']
+    """
+    return [
+        team for team in team_list
+        if not is_team_valid_for_season(team, season)
+    ]
+
+
+def clear_cache() -> None:
+    """
+    Clear the cached team season validity configuration.
+
+    Useful for testing or when the configuration file has been updated.
+    """
+    global _team_season_validity_cache
+    _team_season_validity_cache = None
+    logger.debug("Team season validity cache cleared")

--- a/basketball_reference_webscrapper/web_scrap_nba_api.py
+++ b/basketball_reference_webscrapper/web_scrap_nba_api.py
@@ -22,6 +22,10 @@ from nba_api.stats.library.parameters import SeasonType
 # Local
 from basketball_reference_webscrapper.data_models.feature_model import FeatureIn
 from basketball_reference_webscrapper.utils.logs import get_logger
+from basketball_reference_webscrapper.utils.team_utils import (
+    is_team_valid_for_season,
+    get_excluded_teams_for_season
+)
 
 __all__ = ['WebScrapNBAApi']
 
@@ -608,26 +612,55 @@ class WebScrapNBAApi:
 
     def _filter_teams(self, team_city_refdata: pd.DataFrame) -> pd.DataFrame:
         """
-        Filter teams based on feature input.
+        Filter teams based on feature input and season validity.
+
+        This method filters teams in two stages:
+        1. Based on user input (specific team, list of teams, or 'all')
+        2. Based on season validity (excludes teams not active in requested season)
+
+        This prevents duplicate data from historical team name changes
+        (e.g., CHO vs CHA for Charlotte).
 
         Args:
             team_city_refdata (pd.DataFrame): Full team reference data.
 
         Returns:
-            pd.DataFrame: Filtered team data based on the team parameter.
+            pd.DataFrame: Filtered team data based on the team parameter
+                and season validity.
         """
         team = self.feature_object.team
+        season = self.feature_object.season
 
+        # First filter: based on user input
         if isinstance(team, list):
-            return team_city_refdata[
+            filtered_df = team_city_refdata[
                 team_city_refdata["team_abrev"].isin(team)
             ]
         elif isinstance(team, str) and team != "all":
-            return team_city_refdata[
+            filtered_df = team_city_refdata[
                 team_city_refdata["team_abrev"] == team
             ]
+        else:
+            filtered_df = team_city_refdata
 
-        return team_city_refdata
+        # Second filter: based on season validity
+        # This prevents duplicate fetching for teams with historical name changes
+        all_teams = list(filtered_df["team_abrev"])
+        valid_teams = [
+            team_abbr for team_abbr in all_teams
+            if is_team_valid_for_season(team_abbr, season)
+        ]
+
+        # Log any teams filtered out due to season validity
+        excluded_teams = get_excluded_teams_for_season(all_teams, season)
+        if excluded_teams:
+            logger.info(
+                "Excluded teams not valid for season %d: %s",
+                season,
+                excluded_teams
+            )
+
+        return filtered_df[filtered_df["team_abrev"].isin(valid_teams)]
 
     def _load_config(self) -> Dict:
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "basketball-reference-webscrapper"
-version = "0.7.3"
+version = "0.7.4"
 description = "Python package for Basketball Reference that gathers data by scraping the website"
 authors = ["Yannick Flores <yannick.flores1992@gmail.com>"]
 readme = "README.md"

--- a/tests/test_team_utils.py
+++ b/tests/test_team_utils.py
@@ -1,0 +1,464 @@
+"""
+Unit tests for team_utils module.
+
+Tests the team season validity logic that prevents duplicate data
+from historical team name changes (CHO/CHA, BRK/NJN, etc.).
+"""
+
+import pytest
+from unittest.mock import patch, mock_open
+
+# Import the functions to test
+from basketball_reference_webscrapper.utils.team_utils import (
+    is_team_valid_for_season,
+    filter_valid_teams_for_season,
+    get_excluded_teams_for_season,
+    load_team_season_validity,
+    clear_cache,
+)
+
+
+class TestIsTeamValidForSeason:
+    """Tests for is_team_valid_for_season function."""
+
+    def setup_method(self):
+        """Clear cache before each test to ensure clean state."""
+        clear_cache()
+
+    # -------------------------------------------------------------------------
+    # Charlotte Hornets/Bobcats (CHO/CHA) - Primary bug fix
+    # -------------------------------------------------------------------------
+
+    def test_cho_valid_for_2024(self):
+        """CHO (Charlotte Hornets) should be valid for 2024 season."""
+        assert is_team_valid_for_season("CHO", 2024) is True
+
+    def test_cho_valid_for_2015(self):
+        """CHO should be valid starting from 2015 (rebrand year)."""
+        assert is_team_valid_for_season("CHO", 2015) is True
+
+    def test_cho_invalid_for_2014(self):
+        """CHO should NOT be valid for 2014 (was still Bobcats)."""
+        assert is_team_valid_for_season("CHO", 2014) is False
+
+    def test_cha_valid_for_2010(self):
+        """CHA (Charlotte Bobcats) should be valid for 2010."""
+        assert is_team_valid_for_season("CHA", 2010) is True
+
+    def test_cha_valid_for_2014(self):
+        """CHA should be valid for 2014 (last Bobcats season)."""
+        assert is_team_valid_for_season("CHA", 2014) is True
+
+    def test_cha_invalid_for_2015(self):
+        """CHA should NOT be valid for 2015 (became Hornets)."""
+        assert is_team_valid_for_season("CHA", 2015) is False
+
+    def test_cha_invalid_for_2024(self):
+        """CHA should NOT be valid for 2024."""
+        assert is_team_valid_for_season("CHA", 2024) is False
+
+    # -------------------------------------------------------------------------
+    # Brooklyn/New Jersey Nets (BRK/NJN)
+    # -------------------------------------------------------------------------
+
+    def test_brk_valid_for_2024(self):
+        """BRK (Brooklyn Nets) should be valid for 2024."""
+        assert is_team_valid_for_season("BRK", 2024) is True
+
+    def test_brk_valid_for_2013(self):
+        """BRK should be valid starting from 2013 (move to Brooklyn)."""
+        assert is_team_valid_for_season("BRK", 2013) is True
+
+    def test_brk_invalid_for_2012(self):
+        """BRK should NOT be valid for 2012 (was still NJN)."""
+        assert is_team_valid_for_season("BRK", 2012) is False
+
+    def test_njn_valid_for_2012(self):
+        """NJN (New Jersey Nets) should be valid for 2012."""
+        assert is_team_valid_for_season("NJN", 2012) is True
+
+    def test_njn_invalid_for_2013(self):
+        """NJN should NOT be valid for 2013 (became BRK)."""
+        assert is_team_valid_for_season("NJN", 2013) is False
+
+    # -------------------------------------------------------------------------
+    # Oklahoma City/Seattle (OKC/SEA)
+    # -------------------------------------------------------------------------
+
+    def test_okc_valid_for_2024(self):
+        """OKC should be valid for 2024."""
+        assert is_team_valid_for_season("OKC", 2024) is True
+
+    def test_okc_valid_for_2009(self):
+        """OKC should be valid starting from 2009 (relocation year)."""
+        assert is_team_valid_for_season("OKC", 2009) is True
+
+    def test_okc_invalid_for_2008(self):
+        """OKC should NOT be valid for 2008 (was still SEA)."""
+        assert is_team_valid_for_season("OKC", 2008) is False
+
+    def test_sea_valid_for_2008(self):
+        """SEA (Seattle SuperSonics) should be valid for 2008."""
+        assert is_team_valid_for_season("SEA", 2008) is True
+
+    def test_sea_invalid_for_2009(self):
+        """SEA should NOT be valid for 2009 (became OKC)."""
+        assert is_team_valid_for_season("SEA", 2009) is False
+
+    # -------------------------------------------------------------------------
+    # Memphis/Vancouver Grizzlies (MEM/VAN)
+    # -------------------------------------------------------------------------
+
+    def test_mem_valid_for_2024(self):
+        """MEM should be valid for 2024."""
+        assert is_team_valid_for_season("MEM", 2024) is True
+
+    def test_mem_valid_for_2002(self):
+        """MEM should be valid starting from 2002 (relocation year)."""
+        assert is_team_valid_for_season("MEM", 2002) is True
+
+    def test_mem_invalid_for_2001(self):
+        """MEM should NOT be valid for 2001 (was still VAN)."""
+        assert is_team_valid_for_season("MEM", 2001) is False
+
+    def test_van_valid_for_2001(self):
+        """VAN (Vancouver Grizzlies) should be valid for 2001."""
+        assert is_team_valid_for_season("VAN", 2001) is True
+
+    def test_van_invalid_for_2002(self):
+        """VAN should NOT be valid for 2002 (became MEM)."""
+        assert is_team_valid_for_season("VAN", 2002) is False
+
+    # -------------------------------------------------------------------------
+    # New Orleans Pelicans/Hornets (NOP/NOH)
+    # -------------------------------------------------------------------------
+
+    def test_nop_valid_for_2024(self):
+        """NOP should be valid for 2024."""
+        assert is_team_valid_for_season("NOP", 2024) is True
+
+    def test_nop_valid_for_2014(self):
+        """NOP should be valid starting from 2014 (rebrand year)."""
+        assert is_team_valid_for_season("NOP", 2014) is True
+
+    def test_nop_invalid_for_2013(self):
+        """NOP should NOT be valid for 2013 (was still NOH)."""
+        assert is_team_valid_for_season("NOP", 2013) is False
+
+    def test_noh_valid_for_2010(self):
+        """NOH (New Orleans Hornets) should be valid for 2010."""
+        assert is_team_valid_for_season("NOH", 2010) is True
+
+    def test_noh_invalid_for_2014(self):
+        """NOH should NOT be valid for 2014 (became NOP)."""
+        assert is_team_valid_for_season("NOH", 2014) is False
+
+    # -------------------------------------------------------------------------
+    # Teams with no name changes (always valid since 2000)
+    # -------------------------------------------------------------------------
+
+    @pytest.mark.parametrize("team", [
+        "ATL", "BOS", "CHI", "CLE", "DAL", "DEN", "DET", "GSW", "HOU", "IND",
+        "LAC", "LAL", "MIA", "MIL", "MIN", "NYK", "ORL", "PHI", "PHO", "POR",
+        "SAC", "SAS", "TOR", "UTA", "WAS"
+    ])
+    def test_stable_teams_valid_for_2024(self, team):
+        """Teams with no name changes should be valid for 2024."""
+        assert is_team_valid_for_season(team, 2024) is True
+
+    @pytest.mark.parametrize("team", [
+        "ATL", "BOS", "CHI", "CLE", "DAL", "DEN", "DET", "GSW", "HOU", "IND",
+        "LAC", "LAL", "MIA", "MIL", "MIN", "NYK", "ORL", "PHI", "PHO", "POR",
+        "SAC", "SAS", "TOR", "UTA", "WAS"
+    ])
+    def test_stable_teams_valid_for_2000(self, team):
+        """Teams with no name changes should be valid for 2000."""
+        assert is_team_valid_for_season(team, 2000) is True
+
+    # -------------------------------------------------------------------------
+    # Edge cases
+    # -------------------------------------------------------------------------
+
+    def test_unknown_team_returns_true(self):
+        """Unknown teams should return True (backward compatibility)."""
+        assert is_team_valid_for_season("XYZ", 2024) is True
+
+    def test_boundary_season_start(self):
+        """Test exact boundary at start_season."""
+        # CHO starts at 2015
+        assert is_team_valid_for_season("CHO", 2015) is True
+        assert is_team_valid_for_season("CHO", 2014) is False
+
+    def test_boundary_season_end(self):
+        """Test exact boundary at end_season."""
+        # CHA ends at 2014
+        assert is_team_valid_for_season("CHA", 2014) is True
+        assert is_team_valid_for_season("CHA", 2015) is False
+
+
+class TestFilterValidTeamsForSeason:
+    """Tests for filter_valid_teams_for_season function."""
+
+    def setup_method(self):
+        """Clear cache before each test."""
+        clear_cache()
+
+    def test_filters_out_cha_for_2024(self):
+        """Should filter out CHA when requesting 2024 season."""
+        teams = ["CHO", "CHA", "BOS", "LAL"]
+        result = filter_valid_teams_for_season(teams, 2024)
+
+        assert "CHO" in result
+        assert "CHA" not in result
+        assert "BOS" in result
+        assert "LAL" in result
+
+    def test_filters_out_cho_for_2010(self):
+        """Should filter out CHO when requesting 2010 season."""
+        teams = ["CHO", "CHA", "BOS", "LAL"]
+        result = filter_valid_teams_for_season(teams, 2010)
+
+        assert "CHO" not in result
+        assert "CHA" in result
+        assert "BOS" in result
+        assert "LAL" in result
+
+    def test_filters_multiple_historical_teams_2024(self):
+        """Should filter out all historical teams for 2024."""
+        teams = ["CHO", "CHA", "BRK", "NJN", "OKC", "SEA", "MEM", "VAN", "NOP", "NOH", "BOS"]
+        result = filter_valid_teams_for_season(teams, 2024)
+
+        # Current teams should be present
+        assert "CHO" in result
+        assert "BRK" in result
+        assert "OKC" in result
+        assert "MEM" in result
+        assert "NOP" in result
+        assert "BOS" in result
+
+        # Historical teams should be filtered out
+        assert "CHA" not in result
+        assert "NJN" not in result
+        assert "SEA" not in result
+        assert "VAN" not in result
+        assert "NOH" not in result
+
+    def test_preserves_order(self):
+        """Should preserve the order of teams in the list."""
+        teams = ["BOS", "CHO", "LAL", "GSW"]
+        result = filter_valid_teams_for_season(teams, 2024)
+        assert result == ["BOS", "CHO", "LAL", "GSW"]
+
+    def test_empty_list(self):
+        """Should handle empty list."""
+        result = filter_valid_teams_for_season([], 2024)
+        assert result == []
+
+    def test_all_filtered_out(self):
+        """Should return empty list if all teams filtered out."""
+        teams = ["CHA", "NJN", "SEA", "VAN", "NOH"]
+        result = filter_valid_teams_for_season(teams, 2024)
+        assert result == []
+
+
+class TestGetExcludedTeamsForSeason:
+    """Tests for get_excluded_teams_for_season function."""
+
+    def setup_method(self):
+        """Clear cache before each test."""
+        clear_cache()
+
+    def test_returns_excluded_teams_2024(self):
+        """Should return list of excluded teams for 2024."""
+        teams = ["CHO", "CHA", "BOS"]
+        excluded = get_excluded_teams_for_season(teams, 2024)
+
+        assert "CHA" in excluded
+        assert "CHO" not in excluded
+        assert "BOS" not in excluded
+
+    def test_returns_empty_when_all_valid(self):
+        """Should return empty list when all teams are valid."""
+        teams = ["BOS", "LAL", "GSW"]
+        excluded = get_excluded_teams_for_season(teams, 2024)
+        assert excluded == []
+
+    def test_returns_all_historical_teams_2024(self):
+        """Should return all historical teams for 2024."""
+        teams = ["CHA", "NJN", "SEA", "VAN", "NOH"]
+        excluded = get_excluded_teams_for_season(teams, 2024)
+
+        assert set(excluded) == {"CHA", "NJN", "SEA", "VAN", "NOH"}
+
+
+class TestLoadTeamSeasonValidity:
+    """Tests for load_team_season_validity function."""
+
+    def setup_method(self):
+        """Clear cache before each test."""
+        clear_cache()
+
+    def test_returns_dict(self):
+        """Should return a dictionary."""
+        result = load_team_season_validity()
+        assert isinstance(result, dict)
+
+    def test_contains_expected_teams(self):
+        """Should contain expected team entries."""
+        result = load_team_season_validity()
+
+        # Check a few expected teams
+        assert "CHO" in result
+        assert "CHA" in result
+        assert "BOS" in result
+
+    def test_team_entry_has_required_keys(self):
+        """Each team entry should have start_season key."""
+        result = load_team_season_validity()
+
+        for team, validity in result.items():
+            assert "start_season" in validity, f"{team} missing start_season"
+
+    def test_caching_works(self):
+        """Should cache results and return same object."""
+        result1 = load_team_season_validity()
+        result2 = load_team_season_validity()
+
+        # Should be the exact same object (cached)
+        assert result1 is result2
+
+    def test_clear_cache_reloads(self):
+        """Clearing cache should cause reload on next call."""
+        result1 = load_team_season_validity()
+        clear_cache()
+        result2 = load_team_season_validity()
+
+        # Should have same content but be different objects
+        assert result1 == result2
+        # Note: After clear, it reloads, so they might be same object again
+        # The important thing is that clear_cache doesn't break anything
+
+
+class TestClearCache:
+    """Tests for clear_cache function."""
+
+    def test_clear_cache_does_not_raise(self):
+        """clear_cache should not raise exceptions."""
+        clear_cache()  # Should not raise
+
+    def test_clear_cache_allows_reload(self):
+        """After clear_cache, load should work normally."""
+        load_team_season_validity()
+        clear_cache()
+        result = load_team_season_validity()
+        assert isinstance(result, dict)
+
+
+class TestConfigFileMissing:
+    """Tests for behavior when config file is missing."""
+
+    def setup_method(self):
+        """Clear cache before each test."""
+        clear_cache()
+
+    @patch('basketball_reference_webscrapper.utils.team_utils.importlib_resources')
+    def test_missing_config_returns_empty_dict(self, mock_resources):
+        """Should return empty dict if config file not found."""
+        mock_resources.files.side_effect = FileNotFoundError("File not found")
+
+        result = load_team_season_validity()
+        assert result == {}
+
+    @patch('basketball_reference_webscrapper.utils.team_utils.load_team_season_validity')
+    def test_missing_config_all_teams_valid(self, mock_load):
+        """All teams should be valid when config is missing."""
+        mock_load.return_value = {}
+
+        # With empty config, all teams should be valid
+        assert is_team_valid_for_season("CHA", 2024) is True
+        assert is_team_valid_for_season("CHO", 2024) is True
+        assert is_team_valid_for_season("XYZ", 2024) is True
+
+
+class TestIntegrationScenarios:
+    """Integration tests simulating real usage scenarios."""
+
+    def setup_method(self):
+        """Clear cache before each test."""
+        clear_cache()
+
+    def test_scenario_fetch_all_teams_2024(self):
+        """Simulate fetching all teams for 2024 season."""
+        # This simulates what team_city_refdata might contain
+        all_teams = [
+            "ATL", "BOS", "BRK", "CHA", "CHI", "CHO", "CLE", "DAL", "DEN", "DET",
+            "GSW", "HOU", "IND", "LAC", "LAL", "MEM", "MIA", "MIL", "MIN", "NJN",
+            "NOP", "NOH", "NYK", "OKC", "ORL", "PHI", "PHO", "POR", "SAC", "SAS",
+            "SEA", "TOR", "UTA", "VAN", "WAS"
+        ]
+
+        valid_teams = filter_valid_teams_for_season(all_teams, 2024)
+
+        # Should have exactly 30 teams (current NBA)
+        assert len(valid_teams) == 30
+
+        # Historical teams should be excluded
+        assert "CHA" not in valid_teams  # Use CHO
+        assert "NJN" not in valid_teams  # Use BRK
+        assert "SEA" not in valid_teams  # Use OKC
+        assert "VAN" not in valid_teams  # Use MEM
+        assert "NOH" not in valid_teams  # Use NOP
+
+        # Current teams should be included
+        assert "CHO" in valid_teams
+        assert "BRK" in valid_teams
+        assert "OKC" in valid_teams
+        assert "MEM" in valid_teams
+        assert "NOP" in valid_teams
+
+    def test_scenario_fetch_all_teams_2005(self):
+        """Simulate fetching all teams for 2005 season."""
+        all_teams = [
+            "ATL", "BOS", "BRK", "CHA", "CHI", "CHO", "CLE", "DAL", "DEN", "DET",
+            "GSW", "HOU", "IND", "LAC", "LAL", "MEM", "MIA", "MIL", "MIN", "NJN",
+            "NOP", "NOH", "NYK", "OKC", "ORL", "PHI", "PHO", "POR", "SAC", "SAS",
+            "SEA", "TOR", "UTA", "VAN", "WAS"
+        ]
+
+        valid_teams = filter_valid_teams_for_season(all_teams, 2005)
+
+        # For 2005:
+        # - CHA valid (Bobcats started 2005), CHO invalid
+        # - NJN valid, BRK invalid
+        # - SEA valid, OKC invalid
+        # - MEM valid, VAN invalid (moved 2002)
+        # - NOH valid, NOP invalid
+
+        assert "CHA" in valid_teams
+        assert "CHO" not in valid_teams
+
+        assert "NJN" in valid_teams
+        assert "BRK" not in valid_teams
+
+        assert "SEA" in valid_teams
+        assert "OKC" not in valid_teams
+
+        assert "MEM" in valid_teams
+        assert "VAN" not in valid_teams
+
+    def test_scenario_single_team_request(self):
+        """Simulate requesting a single team."""
+        # User requests CHO for 2024 - should work
+        teams = ["CHO"]
+        valid = filter_valid_teams_for_season(teams, 2024)
+        assert valid == ["CHO"]
+
+        # User requests CHA for 2024 - should be filtered out
+        teams = ["CHA"]
+        valid = filter_valid_teams_for_season(teams, 2024)
+        assert valid == []
+
+        # User requests CHA for 2010 - should work
+        teams = ["CHA"]
+        valid = filter_valid_teams_for_season(teams, 2010)
+        assert valid == ["CHA"]


### PR DESCRIPTION
Introduces a mechanism to filter teams based on their valid season ranges. This prevents fetching duplicate data associated with historical team name changes and relocations, such as Charlotte Hornets/Bobcats or New Jersey/Brooklyn Nets.

Adds a YAML configuration file mapping team abbreviations to their valid season ranges and utility functions for checking team validity and filtering team lists. This logic is integrated into the API data filtering process.